### PR TITLE
Return larger set of generally available repositories

### DIFF
--- a/frontend/app/lib/util/github-api.ts
+++ b/frontend/app/lib/util/github-api.ts
@@ -76,7 +76,7 @@ export function useGenerallyAvailableRepositories(account: string): {
   error: any;
   data: undefined | Project[];
 } {
-  const url = `https://api.github.com/users/${account}/repos`;
+  const url = `https://api.github.com/users/${account}/repos?per_page=100`;
   const { data, error, isLoading } = useSWR(url, getFetcher, SWRConfig);
   console.log("swr ga data", data);
   if (isLoading || error) {


### PR DESCRIPTION
fix issue where smaller subset of generally available repositories was returned.

This implementation is not the ideal solution, because it does not scale with the amount of repositories owned.

To get to what I'm imagining, we'll need to implement #42 
Afterwards, when we start paginating, we can start lazily loading the next set of generally available repos. Adding more details on pagination to relevant issue...

This PR will close #44 for now. After pagination is introduced in a newer version, we can revisit the implementation to include some more complex behavior.